### PR TITLE
Reuse the tio_SOURCES variable in src/Makefile.am

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -14,25 +14,13 @@ tio_SOURCES = tty.c \
               include/tio/log.h \
               include/tio/error.h
 
-tionc_SOURCES = tty.c \
-              options.c \
-              time.c \
-              main.c \
-              log.c \
-              error.c \
-              include/tio/tty.h \
-              include/tio/options.h \
-              include/tio/time.h \
-              include/tio/print.h \
-              include/tio/log.h \
-              include/tio/error.h
-
-tionc_CFLAGS = -D TIO_NOCOLOR
-
 if ADD_SETSPEED2
 tio_SOURCES += setspeed2.c
-tionc_SOURCES += setspeed2.c
 endif
+
+tionc_SOURCES = $(tio_SOURCES)
+
+tionc_CFLAGS = -D TIO_NOCOLOR
 
 if ENABLE_BASH_COMPLETION
 bashcompletiondir=@BASH_COMPLETION_DIR@


### PR DESCRIPTION
The only difference between `tio` and `tionc`
is the compile time flag 'TIO_NOCOLOR'.